### PR TITLE
remove problematic parentheses

### DIFF
--- a/Courses/Classes_n_Exceptions/tp.md
+++ b/Courses/Classes_n_Exceptions/tp.md
@@ -47,7 +47,7 @@ p1 = Point(x=0, y=0)  # call __init__ ;
 print(p1.x)
 print(p1.y)
 print("{0}".format(p1))  # call __str__
-p1()
+p1
 ```
 
 


### PR DESCRIPTION
`p1()` leads to an error : `'Point' object is not callable`
I guess it should just be `p1`