### PR TITLE
Add url to bicycle_db file

### DIFF
--- a/Courses/Python-modules/tp.md
+++ b/Courses/Python-modules/tp.md
@@ -253,7 +253,7 @@ Python module/package names should generally follow the following constraints:
 - Underscore-separated or no word separators at all, and do not use hyphens (i.e., use _ not -).
 
 We are going to create a module called `biketrauma` to visualize the `bicycle_db` used in the the following lectures.
-XXX TODO (reconnect with where this is downloaded)
+The file is available at the following URL: <https://koumoul.com/s/data-fair/api/v1/datasets/accidents-velos/raw>.
 
 ### Module structure
 


### PR DESCRIPTION
I add the url used in the bash course to get the `accidents-velo.csv` file needed here for the exercise.

Additionally, I should mention that the link given in the `Exercise : Create a bunch of files` (lign 321) leads to a 404 error, though I don't know where it was supposed to lead so I can't change it...

Hope this helps