### PR TITLE
typo correction of column convertion in Load_db

### DIFF
--- a/Courses/Python-modules/modules_files/Load_db.py
+++ b/Courses/Python-modules/modules_files/Load_db.py
@@ -9,5 +9,5 @@ class Load_db:
   
   @staticmethod
   def save_as_df():
-    df_bikes = pd.read_csv(path_target, na_values="", low_memory=False, converters={'data': str, 'heure': str})
+    df_bikes = pd.read_csv(path_target, na_values="", low_memory=False, converters={'date': str, 'heure': str})
     return df_bikes


### PR DESCRIPTION
'Converters' option of pandas.read_csv function is meant to convert the column 'date'.
This prevents issues when creating the 'format_date' function.